### PR TITLE
Don't raise events until event system has been initialized

### DIFF
--- a/web/concrete/src/Localization/Localization.php
+++ b/web/concrete/src/Localization/Localization.php
@@ -191,9 +191,11 @@ class Localization
         $this->contextLocales[$context] = $locale;
         if ($context === $this->activeContext) {
             PunicData::setDefaultLocale($locale);
-            $event = new \Symfony\Component\EventDispatcher\GenericEvent();
-            $event->setArgument('locale', $locale);
-            Events::dispatch('on_locale_load', $event);
+            if (class_exists('\Events')) {
+                $event = new \Symfony\Component\EventDispatcher\GenericEvent();
+                $event->setArgument('locale', $locale);
+                Events::dispatch('on_locale_load', $event);
+            }
         }
     }
 


### PR DESCRIPTION
Since the `system` context is used very early in the boot process, the `setContextLocale` method is called even before `Events` exists...
